### PR TITLE
feat: add overwrite mode for output file handling

### DIFF
--- a/main.go
+++ b/main.go
@@ -100,7 +100,7 @@ func init() {
 	rootCmd.Flags().BoolVarP(&batchMode, "batch", "b", false, "Batch process all images in directory")
 	rootCmd.Flags().IntVarP(&workers, "workers", "", 4, "Number of worker goroutines for batch processing")
 	rootCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose output")
-	rootCmd.Flags().BoolVarP(&overwrite, "overwrite", "r", false, "Overwrite original files instead of creating new ones")
+	rootCmd.Flags().BoolVar(&overwrite, "overwrite", false, "Overwrite original files instead of creating new ones")
 
 	// PreRun: Validate and set up parameters before running the main command
 	rootCmd.PreRun = func(cmd *cobra.Command, args []string) {

--- a/main.go
+++ b/main.go
@@ -129,6 +129,12 @@ func init() {
 			slog.Error("Quality must be between 1 and 100")
 			os.Exit(1)
 		}
+
+		// Validate overwrite and output flags combination
+		if overwrite && outputDir != "" {
+			slog.Error("Cannot use --overwrite with --output: --overwrite replaces original files in place")
+			os.Exit(1)
+		}
 	}
 }
 
@@ -405,15 +411,11 @@ func calculateTargetSize(originalWidth, originalHeight int) (int, int) {
 /*
 generateOutputPath creates the output file path for the resized image,
 including the new dimensions in the filename and using the specified output directory if provided.
-If overwrite is enabled, returns the original file path or the same filename in the output directory.
+If overwrite is enabled, returns the original file path (ignoring outputDir).
 */
 func generateOutputPath(inputPath, outputDir string, width, height int) string {
-	// If overwrite mode is enabled, return original file path or same filename in output directory
+	// If overwrite mode is enabled, always return original file path
 	if overwrite {
-		if outputDir != "" {
-			filename := filepath.Base(inputPath)
-			return filepath.Join(outputDir, filename)
-		}
 		return inputPath
 	}
 


### PR DESCRIPTION
- Add an --overwrite flag to allow overwriting original files instead of creating new ones
- Show a warning message when overwrite mode is enabled
- Update output path generation logic to support overwriting files, including handling output directory if specified
- Add usage example demonstrating the new overwrite option

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `--overwrite` command-line option to allow resized images to overwrite the original files instead of creating new ones.
  * Updated usage examples and verbose mode to indicate when original files will be overwritten.
  * Added validation to prevent using `--overwrite` together with the output directory option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->