### PR TITLE
refactor: deduplicate worker pool and simplify processing

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -5,7 +5,6 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
-	"strings"
 	"sync"
 )
 
@@ -31,29 +30,34 @@ func processBatch(dirPath string) {
 		return
 	}
 
-	fmt.Printf("Found %d image files\n", len(imageFiles))
+	runWorkerPool(imageFiles)
+}
+
+/*
+runWorkerPool resizes the given image files concurrently using a pool of worker
+goroutines and prints a summary of the results.
+*/
+func runWorkerPool(files []string) {
+	fmt.Printf("Found %d image files\n", len(files))
 
 	// Create channels for jobs and results for the worker pool
-	jobs := make(chan string, len(imageFiles))
-	results := make(chan error, len(imageFiles))
+	jobs := make(chan string, len(files))
+	results := make(chan error, len(files))
 
 	// Start worker goroutines to process images concurrently
 	var wg sync.WaitGroup
 	for i := 0; i < workers; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			for filePath := range jobs {
-				err := resizeImage(filePath)
-				results <- err
+				results <- resizeImage(filePath)
 			}
-		}()
+		})
 	}
 
 	// Send image file paths to the jobs channel
 	go func() {
 		defer close(jobs)
-		for _, filePath := range imageFiles {
+		for _, filePath := range files {
 			jobs <- filePath
 		}
 	}()
@@ -87,7 +91,6 @@ Returns a slice of file paths and any error encountered.
 */
 func collectImageFiles(dirPath string) ([]string, error) {
 	var imageFiles []string
-	supportedExts := supportedImageExts()
 
 	// Walk through the directory and collect files with supported extensions
 	err := filepath.Walk(dirPath, func(path string, info os.FileInfo, err error) error {
@@ -95,11 +98,8 @@ func collectImageFiles(dirPath string) ([]string, error) {
 			return err
 		}
 
-		if !info.IsDir() {
-			ext := strings.ToLower(filepath.Ext(path))
-			if supportedExts[ext] {
-				imageFiles = append(imageFiles, path)
-			}
+		if !info.IsDir() && isImageFile(path) {
+			imageFiles = append(imageFiles, path)
 		}
 
 		return nil

--- a/config.go
+++ b/config.go
@@ -26,9 +26,6 @@ var (
 
 // setupConfig initializes the CLI configuration, flags, and validation
 func setupConfig() {
-	// Set up logger
-	setupLogger()
-
 	// Add version command
 	rootCmd.AddCommand(createVersionCommand())
 
@@ -56,16 +53,19 @@ func setupConfig() {
 
 // validateConfig validates the configuration parameters
 func validateConfig(cmd *cobra.Command, args []string) {
+	// Configure the logger now that flags (including --verbose) have been parsed
+	setupLogger()
+
 	// Check if dimensions were explicitly set by the user
 	widthSet = cmd.Flags().Changed("width")
 	heightSet = cmd.Flags().Changed("height")
 
-	// If neither width nor height is set, use default values
+	// If neither width nor height is set, default to width 800 (height
+	// auto-calculated from the aspect ratio). height/heightSet already hold
+	// their zero values here, so only the width side needs setting.
 	if !widthSet && !heightSet {
 		width = 800
-		height = 0 // Auto-calculate based on aspect ratio
 		widthSet = true
-		heightSet = false
 	}
 
 	// Validate input parameters

--- a/extensions.go
+++ b/extensions.go
@@ -11,15 +11,13 @@ const (
 	extBMP  = ".bmp"
 )
 
-// supportedImageExts returns the set of image file extensions the tool accepts.
-func supportedImageExts() map[string]bool {
-	return map[string]bool{
-		extJPG:  true,
-		extJPEG: true,
-		extPNG:  true,
-		extGIF:  true,
-		extTIFF: true,
-		extTIF:  true,
-		extBMP:  true,
-	}
+// supportedImageExts is the set of image file extensions the tool accepts.
+var supportedImageExts = map[string]bool{
+	extJPG:  true,
+	extJPEG: true,
+	extPNG:  true,
+	extGIF:  true,
+	extTIFF: true,
+	extTIF:  true,
+	extBMP:  true,
 }

--- a/processor.go
+++ b/processor.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"sync"
 
 	"github.com/appleboy/com/file"
 	"github.com/disintegration/imaging"
@@ -42,16 +41,7 @@ func processImages(cmd *cobra.Command, args []string) {
 			os.Exit(1)
 		}
 
-		if len(imageFiles) == 1 {
-			// Single image file
-			if err := resizeImage(imageFiles[0]); err != nil {
-				slog.Error(fmt.Sprintf("Failed to process image: %v", err))
-				os.Exit(1)
-			}
-		} else {
-			// Multiple image files
-			processMultipleFiles(imageFiles)
-		}
+		resizeFiles(imageFiles)
 		return
 	}
 
@@ -72,16 +62,7 @@ func processImages(cmd *cobra.Command, args []string) {
 			os.Exit(1)
 		}
 
-		if len(files) == 1 {
-			// Single file matched, process it normally
-			if err := resizeImage(files[0]); err != nil {
-				slog.Error(fmt.Sprintf("Failed to process image: %v", err))
-				os.Exit(1)
-			}
-		} else {
-			// Multiple files matched, process them in batch
-			processMultipleFiles(files)
-		}
+		resizeFiles(files)
 		return
 	}
 
@@ -102,6 +83,21 @@ func processImages(cmd *cobra.Command, args []string) {
 			os.Exit(1)
 		}
 	}
+}
+
+/*
+resizeFiles dispatches a list of image files: a single file is resized directly
+(with rich per-file output), while multiple files go through the worker pool.
+*/
+func resizeFiles(files []string) {
+	if len(files) == 1 {
+		if err := resizeImage(files[0]); err != nil {
+			slog.Error(fmt.Sprintf("Failed to process image: %v", err))
+			os.Exit(1)
+		}
+		return
+	}
+	processMultipleFiles(files)
 }
 
 /*
@@ -140,22 +136,18 @@ func resizeImage(inputPath string) error {
 
 	var resized image.Image
 
-	// Choose resizing method based on flags
-	if (widthSet && heightSet && keepRatio) || (!widthSet && heightSet) ||
-		(widthSet && !heightSet) {
-		// Keep aspect ratio
-		switch {
-		case widthSet && !heightSet:
-			// Only width set, height is auto-calculated
-			resized = imaging.Resize(src, targetWidth, 0, imaging.Lanczos)
-		case !widthSet && heightSet:
-			// Only height set, width is auto-calculated
-			resized = imaging.Resize(src, 0, targetHeight, imaging.Lanczos)
-		default:
-			// Both set, but keep ratio (fit within bounds)
-			resized = imaging.Fit(src, targetWidth, targetHeight, imaging.Lanczos)
-		}
-	} else {
+	// Choose resizing method based on which dimensions were set and the keep-ratio flag
+	switch {
+	case widthSet && !heightSet:
+		// Only width set, height is auto-calculated
+		resized = imaging.Resize(src, targetWidth, 0, imaging.Lanczos)
+	case !widthSet && heightSet:
+		// Only height set, width is auto-calculated
+		resized = imaging.Resize(src, 0, targetHeight, imaging.Lanczos)
+	case keepRatio:
+		// Both set, keep ratio (fit within bounds)
+		resized = imaging.Fit(src, targetWidth, targetHeight, imaging.Lanczos)
+	default:
 		// Force resize to exact dimensions (may distort aspect ratio)
 		resized = imaging.Resize(src, targetWidth, targetHeight, imaging.Lanczos)
 	}
@@ -180,13 +172,7 @@ func resizeImage(inputPath string) error {
 	switch ext {
 	case extJPG, extJPEG:
 		saveErr = imaging.Save(resized, outputPath, imaging.JPEGQuality(quality))
-	case extPNG:
-		saveErr = imaging.Save(resized, outputPath)
-	case extGIF:
-		saveErr = imaging.Save(resized, outputPath)
-	case extTIFF, extTIF:
-		saveErr = imaging.Save(resized, outputPath)
-	case extBMP:
+	case extPNG, extGIF, extTIFF, extTIF, extBMP:
 		saveErr = imaging.Save(resized, outputPath)
 	default:
 		return fmt.Errorf("unsupported image format: %s", ext)
@@ -287,7 +273,7 @@ Returns true if the file extension is one of: jpg, jpeg, png, gif, tiff, tif, bm
 */
 func isImageFile(path string) bool {
 	ext := strings.ToLower(filepath.Ext(path))
-	return supportedImageExts()[ext]
+	return supportedImageExts[ext]
 }
 
 /*
@@ -320,8 +306,8 @@ func expandGlobPattern(pattern string) ([]string, error) {
 }
 
 /*
-processMultipleFiles processes multiple image files using a worker pool.
-Similar to processBatch but works with a pre-defined list of files.
+processMultipleFiles processes a pre-defined list of image files using a worker pool.
+Similar to processBatch but works with an explicit list rather than a directory walk.
 */
 func processMultipleFiles(files []string) {
 	if verbose {
@@ -329,52 +315,5 @@ func processMultipleFiles(files []string) {
 		fmt.Printf("Using %d workers\n", workers)
 	}
 
-	fmt.Printf("Found %d image files\n", len(files))
-
-	// Create channels for jobs and results for the worker pool
-	jobs := make(chan string, len(files))
-	results := make(chan error, len(files))
-
-	// Start worker goroutines to process images concurrently
-	var wg sync.WaitGroup
-	for i := 0; i < workers; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			for filePath := range jobs {
-				err := resizeImage(filePath)
-				results <- err
-			}
-		}()
-	}
-
-	// Send image file paths to the jobs channel
-	go func() {
-		defer close(jobs)
-		for _, filePath := range files {
-			jobs <- filePath
-		}
-	}()
-
-	// Close the results channel after all workers are done
-	go func() {
-		wg.Wait()
-		close(results)
-	}()
-
-	// Collect and count results from workers
-	successCount := 0
-	errorCount := 0
-	for err := range results {
-		if err != nil {
-			if verbose {
-				fmt.Printf("Error: %v\n", err)
-			}
-			errorCount++
-		} else {
-			successCount++
-		}
-	}
-
-	fmt.Printf("Batch processing completed: %d success, %d errors\n", successCount, errorCount)
+	runWorkerPool(files)
 }


### PR DESCRIPTION
## Summary
Quality-only cleanup of the image-processing code paths: removes duplicated worker-pool orchestration, builds the supported-extensions set once, and collapses repeated switch/conditional branches. No change to the actual resize output — net ~63 fewer lines.

## AI Authorship
- [x] AI was used. Details:
  - **Tool / model**: Claude Code (Opus 4.8)
  - **AI-authored files**: `batch.go`, `config.go`, `extensions.go`, `processor.go`
  - **Human line-by-line reviewed**: pending author confirmation

## Change classification
- [x] Core code (the CLI's central processing path) — but behavior-preserving and fully covered by the existing test suite.

## What changed
- Extracted a shared `runWorkerPool` helper used by both directory batch and explicit file-list processing (was duplicated ~45 lines across `batch.go` / `processor.go`); adopted Go 1.25 `WaitGroup.Go`.
- Promoted `supportedImageExts` from a function rebuilding a map per call to a package-level `var` built once — removes a per-file allocation in the `isImageFile` hot path.
- `collectImageFiles` now reuses `isImageFile` instead of inlining the extension check.
- Collapsed the resize-method conditional (outer boolean that re-tested the same flags as its inner switch) into a single switch, and merged the five identical save-format `case` arms into one.
- Extracted a `resizeFiles` dispatch helper for the one-vs-many file branches in `processImages`.
- Moved `setupLogger()` from `init()` time into the cobra `PreRun`, so `--verbose` can actually raise the log level (was latent: only `slog.Error` is currently used).
- Dropped no-op default assignments in `validateConfig`.

## Verification
- [x] `go build ./...` — passes
- [x] `go vet ./...` — clean
- [x] `go test ./...` — passes (existing suite, unchanged)
- [x] `golangci-lint run` — 0 issues
- No new tests added: this is a behavior-preserving refactor covered by the existing tests.

## Risk & rollback
- **Risk**: Low. Logic is preserved; the only observable change is that `--verbose` now correctly sets the slog level (no current debug/info logs, so effectively inert).
- **Rollback**: revert the single commit.

## Reviewer guide
- **Read carefully**: the new `runWorkerPool` in `batch.go` and the resize-method switch in `processor.go` (verify the collapsed conditions are equivalent to the originals).
- **Spot-check OK**: `extensions.go`, `config.go` — mechanical changes.
