### PR TITLE
fix: harden path, worker, and resize edge cases

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -40,16 +40,19 @@ goroutines and prints a summary of the results.
 func runWorkerPool(files []string) {
 	fmt.Printf("Found %d image files\n", len(files))
 
+	// Never start more workers than there are files to process.
+	workerCount := min(workers, len(files))
+
 	// Create channels for jobs and results for the worker pool
 	jobs := make(chan string, len(files))
 	results := make(chan error, len(files))
 
 	// Start worker goroutines to process images concurrently
 	var wg sync.WaitGroup
-	for i := 0; i < workers; i++ {
+	for range workerCount {
 		wg.Go(func() {
 			for filePath := range jobs {
-				results <- resizeImage(filePath)
+				results <- resizeImage(filePath, false)
 			}
 		})
 	}
@@ -92,13 +95,14 @@ Returns a slice of file paths and any error encountered.
 func collectImageFiles(dirPath string) ([]string, error) {
 	var imageFiles []string
 
-	// Walk through the directory and collect files with supported extensions
-	err := filepath.Walk(dirPath, func(path string, info os.FileInfo, err error) error {
+	// Walk through the directory and collect files with supported extensions.
+	// WalkDir avoids an lstat per entry (it only needs the dir-entry type here).
+	err := filepath.WalkDir(dirPath, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
 
-		if !info.IsDir() && isImageFile(path) {
+		if !d.IsDir() && isImageFile(path) {
 			imageFiles = append(imageFiles, path)
 		}
 

--- a/batch.go
+++ b/batch.go
@@ -15,7 +15,6 @@ It collects image files, distributes them to worker goroutines, and prints a sum
 func processBatch(dirPath string) {
 	if verbose {
 		fmt.Printf("Processing directory: %s\n", dirPath)
-		fmt.Printf("Using %d workers\n", workers)
 	}
 
 	// Collect all image files in the directory
@@ -42,6 +41,9 @@ func runWorkerPool(files []string) {
 
 	// Never start more workers than there are files to process.
 	workerCount := min(workers, len(files))
+	if verbose {
+		fmt.Printf("Using %d workers\n", workerCount)
+	}
 
 	// Create channels for jobs and results for the worker pool
 	jobs := make(chan string, len(files))

--- a/config.go
+++ b/config.go
@@ -81,6 +81,10 @@ func validateConfig(cmd *cobra.Command, args []string) {
 		slog.Error("Quality must be between 1 and 100")
 		os.Exit(1)
 	}
+	if workers < 1 {
+		slog.Error("Number of workers must be at least 1")
+		os.Exit(1)
+	}
 
 	// Validate overwrite and output flags combination
 	if overwrite && outputDir != "" {

--- a/processor.go
+++ b/processor.go
@@ -67,13 +67,9 @@ func processImages(cmd *cobra.Command, args []string) {
 	}
 
 	// Check if the input path exists and is accessible
-	info, err := os.Stat(inputPath)
+	info, err := statInputPath(inputPath)
 	if err != nil {
-		if os.IsNotExist(err) {
-			slog.Error(fmt.Sprintf("Path does not exist: %s", inputPath))
-		} else {
-			slog.Error(fmt.Sprintf("Cannot access path: %s, error: %v", inputPath, err))
-		}
+		slog.Error(err.Error())
 		os.Exit(1)
 	}
 
@@ -87,6 +83,23 @@ func processImages(cmd *cobra.Command, args []string) {
 			os.Exit(1)
 		}
 	}
+}
+
+/*
+statInputPath stats a single input path, returning a descriptive error if it
+does not exist or cannot be accessed. Keeping this separate from processImages
+(which calls os.Exit) makes the not-exist vs other-error handling unit-testable
+and guarantees a nil FileInfo is never paired with a nil error.
+*/
+func statInputPath(inputPath string) (os.FileInfo, error) {
+	info, err := os.Stat(inputPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("path does not exist: %s", inputPath)
+		}
+		return nil, fmt.Errorf("cannot access path %s: %w", inputPath, err)
+	}
+	return info, nil
 }
 
 /*

--- a/processor.go
+++ b/processor.go
@@ -321,7 +321,6 @@ Similar to processBatch but works with an explicit list rather than a directory 
 func processMultipleFiles(files []string) {
 	if verbose {
 		fmt.Printf("Processing %d files\n", len(files))
-		fmt.Printf("Using %d workers\n", workers)
 	}
 
 	runWorkerPool(files)

--- a/processor.go
+++ b/processor.go
@@ -66,10 +66,14 @@ func processImages(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	// Check if the input path exists
+	// Check if the input path exists and is accessible
 	info, err := os.Stat(inputPath)
-	if os.IsNotExist(err) {
-		slog.Error(fmt.Sprintf("Path does not exist: %s", inputPath))
+	if err != nil {
+		if os.IsNotExist(err) {
+			slog.Error(fmt.Sprintf("Path does not exist: %s", inputPath))
+		} else {
+			slog.Error(fmt.Sprintf("Cannot access path: %s, error: %v", inputPath, err))
+		}
 		os.Exit(1)
 	}
 
@@ -78,7 +82,7 @@ func processImages(cmd *cobra.Command, args []string) {
 		processBatch(inputPath)
 	} else {
 		// Process a single image file
-		if err := resizeImage(inputPath); err != nil {
+		if err := resizeImage(inputPath, true); err != nil {
 			slog.Error(fmt.Sprintf("Failed to process image: %v", err))
 			os.Exit(1)
 		}
@@ -91,7 +95,7 @@ resizeFiles dispatches a list of image files: a single file is resized directly
 */
 func resizeFiles(files []string) {
 	if len(files) == 1 {
-		if err := resizeImage(files[0]); err != nil {
+		if err := resizeImage(files[0], true); err != nil {
 			slog.Error(fmt.Sprintf("Failed to process image: %v", err))
 			os.Exit(1)
 		}
@@ -102,9 +106,12 @@ func resizeFiles(files []string) {
 
 /*
 resizeImage resizes a single image file according to the specified parameters.
-It preserves aspect ratio if required, saves the output, and prints information if verbose is enabled.
+It preserves aspect ratio if required, saves the output, and prints information
+if verbose is enabled. When detailed is true (single-file runs) it prints the
+per-file result block; in the worker pool detailed is false so concurrent
+goroutines don't interleave their output.
 */
-func resizeImage(inputPath string) error {
+func resizeImage(inputPath string, detailed bool) error {
 	if verbose {
 		fmt.Printf("Processing: %s\n", inputPath)
 		if overwrite {
@@ -118,10 +125,10 @@ func resizeImage(inputPath string) error {
 		return fmt.Errorf("failed to open image %s: %v", inputPath, err)
 	}
 
-	// Get original image dimensions
+	// Get original image dimensions (Dx/Dy account for a non-zero bounds origin)
 	originalBounds := src.Bounds()
-	originalWidth := originalBounds.Max.X
-	originalHeight := originalBounds.Max.Y
+	originalWidth := originalBounds.Dx()
+	originalHeight := originalBounds.Dy()
 
 	if verbose {
 		fmt.Printf("  Original size: %dx%d\n", originalWidth, originalHeight)
@@ -144,18 +151,19 @@ func resizeImage(inputPath string) error {
 	case !widthSet && heightSet:
 		// Only height set, width is auto-calculated
 		resized = imaging.Resize(src, 0, targetHeight, imaging.Lanczos)
-	case keepRatio:
-		// Both set, keep ratio (fit within bounds)
+	case keepRatio && targetWidth > 0 && targetHeight > 0:
+		// Both set to positive values, keep ratio (fit within bounds)
 		resized = imaging.Fit(src, targetWidth, targetHeight, imaging.Lanczos)
 	default:
-		// Force resize to exact dimensions (may distort aspect ratio)
+		// Force resize to the given dimensions (a 0 dimension is auto-derived
+		// by imaging; with both set and no keep-ratio this may distort).
 		resized = imaging.Resize(src, targetWidth, targetHeight, imaging.Lanczos)
 	}
 
 	// Get actual resized dimensions (used for output filename)
 	actualBounds := resized.Bounds()
-	actualWidth := actualBounds.Max.X
-	actualHeight := actualBounds.Max.Y
+	actualWidth := actualBounds.Dx()
+	actualHeight := actualBounds.Dy()
 
 	// Generate output file path
 	outputPath := generateOutputPath(inputPath, outputDir, actualWidth, actualHeight)
@@ -182,8 +190,9 @@ func resizeImage(inputPath string) error {
 		return fmt.Errorf("failed to save image: %v", saveErr)
 	}
 
-	// Print result information if verbose or not in batch mode
-	if verbose || !batchMode {
+	// Print the per-file result block for single-file runs or in verbose mode.
+	// Worker-pool calls pass detailed=false to avoid interleaved concurrent output.
+	if verbose || detailed {
 		fmt.Printf("Resized %s: %dx%d -> %dx%d\n",
 			filepath.Base(inputPath), originalWidth, originalHeight, actualWidth, actualHeight)
 		fmt.Printf("Output: %s\n", outputPath)
@@ -311,7 +320,7 @@ Similar to processBatch but works with an explicit list rather than a directory 
 */
 func processMultipleFiles(files []string) {
 	if verbose {
-		fmt.Printf("Processing %d files from glob pattern\n", len(files))
+		fmt.Printf("Processing %d files\n", len(files))
 		fmt.Printf("Using %d workers\n", workers)
 	}
 

--- a/processor.go
+++ b/processor.go
@@ -106,10 +106,11 @@ func resizeFiles(files []string) {
 
 /*
 resizeImage resizes a single image file according to the specified parameters.
-It preserves aspect ratio if required, saves the output, and prints information
-if verbose is enabled. When detailed is true (single-file runs) it prints the
-per-file result block; in the worker pool detailed is false so concurrent
-goroutines don't interleave their output.
+It preserves aspect ratio if required and saves the output. When detailed is
+true (single-file runs) it prints the per-file result block; worker-pool calls
+pass detailed=false so that, without --verbose, the pool prints only its summary
+instead of per-file blocks. With --verbose every call still prints its progress
+and result lines, so concurrent pool output may interleave.
 */
 func resizeImage(inputPath string, detailed bool) error {
 	if verbose {

--- a/processor_test.go
+++ b/processor_test.go
@@ -429,6 +429,46 @@ func TestResizeImageKeepRatioZeroDimension(t *testing.T) {
 	}
 }
 
+func TestStatInputPath(t *testing.T) {
+	tempDir := t.TempDir()
+
+	regularFile := filepath.Join(tempDir, "afile")
+	if err := os.WriteFile(regularFile, []byte("x"), 0o600); err != nil {
+		t.Fatalf("failed to create file: %v", err)
+	}
+
+	// Both failure modes must return a non-nil error AND a nil FileInfo, so the
+	// caller never dereferences a nil FileInfo. The "parent is a file" case
+	// triggers a non-IsNotExist error (ENOTDIR on unix) — the original panic.
+	errorCases := []struct {
+		name string
+		path string
+	}{
+		{"non-not-exist error (parent is a file)", filepath.Join(regularFile, "sub")},
+		{"non-existent path", filepath.Join(tempDir, "does-not-exist")},
+	}
+	for _, tc := range errorCases {
+		t.Run(tc.name, func(t *testing.T) {
+			info, err := statInputPath(tc.path)
+			if err == nil {
+				t.Fatalf("expected an error, got nil")
+			}
+			if info != nil {
+				t.Errorf("expected nil FileInfo on error, got %v", info)
+			}
+		})
+	}
+
+	// A valid path returns a usable FileInfo and no error.
+	info, err := statInputPath(regularFile)
+	if err != nil {
+		t.Fatalf("unexpected error for valid path: %v", err)
+	}
+	if info == nil || info.IsDir() {
+		t.Errorf("expected a non-dir FileInfo for %s", regularFile)
+	}
+}
+
 func TestProcessImages(t *testing.T) {
 	tempDir := t.TempDir()
 

--- a/processor_test.go
+++ b/processor_test.go
@@ -24,8 +24,8 @@ func createTestImage(path string, width, height int) error {
 	img := image.NewRGBA(image.Rect(0, 0, width, height))
 
 	// Fill with a gradient pattern to make it interesting
-	for y := 0; y < height; y++ {
-		for x := 0; x < width; x++ {
+	for y := range height {
+		for x := range width {
 			r := uint8((x * 255) / width)  // #nosec G115 - Safe conversion for test data
 			g := uint8((y * 255) / height) // #nosec G115 - Safe conversion for test data
 			b := uint8(128)
@@ -347,7 +347,7 @@ func TestResizeImage(t *testing.T) {
 			tt.setupFlags()
 			imagePath := tt.setupImage()
 
-			err := resizeImage(imagePath)
+			err := resizeImage(imagePath, true)
 
 			if tt.expectError {
 				if err == nil {
@@ -583,7 +583,7 @@ func BenchmarkCalculateTargetSize(b *testing.B) {
 	heightSet = false
 
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		calculateTargetSize(1920, 1080)
 	}
 }
@@ -598,7 +598,7 @@ func BenchmarkGenerateOutputPath(b *testing.B) {
 	height := 1080
 
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		generateOutputPath(inputPath, outputDir, width, height)
 	}
 }

--- a/processor_test.go
+++ b/processor_test.go
@@ -382,7 +382,52 @@ func TestResizeImage(t *testing.T) {
 	}
 }
 
-// Helper function to check if string contains substring
+func TestResizeImageKeepRatioZeroDimension(t *testing.T) {
+	tempDir := t.TempDir()
+
+	resetGlobals()
+	width = 0
+	height = 200
+	widthSet = true
+	heightSet = true
+	keepRatio = true
+
+	imagePath := filepath.Join(tempDir, "keepratio.png")
+	if err := createTestImage(imagePath, 400, 300); err != nil {
+		t.Fatalf("Failed to create test image: %v", err)
+	}
+
+	if err := resizeImage(imagePath, true); err != nil {
+		t.Fatalf("resizeImage() returned error: %v", err)
+	}
+
+	// A zero width combined with keep-ratio must not produce a 0x0 image: the
+	// width is derived from the explicit height while preserving aspect ratio.
+	matches, err := filepath.Glob(filepath.Join(tempDir, "keepratio_*.png"))
+	if err != nil {
+		t.Fatalf("glob error: %v", err)
+	}
+	if len(matches) != 1 {
+		t.Fatalf("expected exactly one output file, got %d: %v", len(matches), matches)
+	}
+
+	f, err := os.Open(matches[0])
+	if err != nil {
+		t.Fatalf("failed to open output file: %v", err)
+	}
+	defer f.Close()
+
+	cfg, err := png.DecodeConfig(f)
+	if err != nil {
+		t.Fatalf("failed to decode output config: %v", err)
+	}
+	if cfg.Width <= 0 || cfg.Height <= 0 {
+		t.Errorf("expected non-zero output dimensions, got %dx%d", cfg.Width, cfg.Height)
+	}
+	if cfg.Height != 200 {
+		t.Errorf("expected derived height 200, got %d", cfg.Height)
+	}
+}
 
 func TestProcessImages(t *testing.T) {
 	tempDir := t.TempDir()


### PR DESCRIPTION
## Summary

Hardens the resize-tool CLI against several crash, silent-failure, and degenerate-output edge cases found during a full-codebase review, plus small efficiency and modernization cleanups. No public/CLI-facing behavior changes for normal inputs; the affected paths are error handling, the worker pool, and edge-case dimension handling.

## AI Authorship
- [ ] No AI was used in this PR
- [x] AI was used. Details:
  - **Tool / model**: Claude Opus 4.8 (Claude Code), via a max-effort code review + `--fix`
  - **AI-authored files**: `batch.go`, `config.go`, `processor.go`, `processor_test.go` (all changes)
  - **Human line-by-line reviewed**: none yet — author is relying on green build/vet/test/lint and the reviewer's line-by-line pass

## Change classification
- [ ] Leaf node (local impact)
- [x] Core code — these are the central CLI processing paths (path dispatch, worker pool, resize logic), so a bug here affects every invocation.

## What changed (and why)

Correctness:
- **Path-stat nil-pointer panic** (`processor.go`): the single-arg path only handled `os.IsNotExist`; any other `os.Stat` error (e.g. `ENOTDIR` from `photo.jpg/x`, or `EACCES` on an unreadable parent) left `info == nil` and then `info.IsDir()` panicked. Now all errors report cleanly and exit.
- **`--workers 0` silent no-op** (`config.go`): no validation existed, so a worker count below 1 started zero goroutines and printed `0 success, 0 errors` with exit 0. Added a `workers < 1` check.
- **Interleaved concurrent output** (`processor.go`): `batchMode` was the wrong proxy for "running in the worker pool", so glob / multi-arg / bare-directory runs printed garbled per-file blocks from N goroutines. Threaded a `detailed` flag — single-file runs print details; pool runs stay quiet unless `--verbose`.
- **`imaging.Fit` with a 0 dimension** (`processor.go`): `--width 0 --height N --keep-ratio` silently produced a 0×0 image. Guarded keep-ratio to positive dims; the 0 case now falls to `Resize`, which auto-derives the missing side.
- **Dimensions from `Max.X/Max.Y`** (`processor.go`): switched to `Dx()/Dy()` so a non-zero bounds origin can't corrupt aspect math or the `_WxH` filename.

Efficiency / cleanup:
- `filepath.Walk` → `filepath.WalkDir` (drops an lstat per entry).
- Worker pool capped at `min(workers, len(files))`.
- Modernized loops (`for range N`, `for b.Loop()`), fixed a misleading "from glob pattern" verbose message.

## Verification
- [x] Unit tests — existing suite (`TestCalculateTargetSize`, `TestGenerateOutputPath`, `TestIsImageFile`, etc.) passes.
- [x] Integration-style tests — `TestProcessImages`, `TestProcessMultipleFiles`, `TestProcessImagesWithGlobPattern` (single / batch / glob) pass.
- [x] Error-path coverage — non-existent file, unsupported format, invalid image data.
- [ ] **No new tests were added for the new guards** (`workers < 1` and the non-`IsNotExist` stat path call `os.Exit`, so they aren't unit-testable without a process harness). The keep-ratio-zero and `Dx/Dy` paths are exercised indirectly by existing cases. Reviewer may want a small refactor to make `validateConfig` testable.
- Manual verification: `gofmt -l` clean · `go build ./...` OK · `go vet ./...` OK · `go test ./...` PASS · `golangci-lint run` → **0 issues**.

## Verifiability check
- [x] Inputs/outputs documented in the description above.
- [x] Reviewer can judge correctness from function signatures + the existing test suite for most changes; the new guards need a read.
- [x] Failures surface via the CLI's existing slog error output and exit codes.

## Security check
- [x] No secrets in the diff.
- [x] External inputs (file paths, flags) — path errors now handled; dimension/worker flags validated.
- N/A — no network, auth, payments, or external API surface; filesystem-only CLI.

## Risk & rollback
- **Risk**: Low. The most behavior-visible change is that glob/multi-file/bare-directory runs now print a clean summary instead of interleaved per-file blocks (per-file detail still available with `--verbose`). `--workers 0` now errors instead of no-op'ing.
- **Rollback**: single commit — `git revert 645973e` (or close the PR).

## Reviewer guide
- **Read carefully**:
  - `processor.go` — `resizeImage` (new `detailed` param + the `verbose || detailed` print gate), the resize `switch` (keep-ratio guard), and the `os.Stat` error block in `processImages`.
  - `config.go` — the new `workers < 1` validation.
- **Spot-check OK**:
  - `batch.go` — `WalkDir` swap and `min()` worker cap (mechanical).
  - `processor_test.go` — call-site update + loop/benchmark modernizations (covered by the suite passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
